### PR TITLE
Implemented relation membership test via getRelations()

### DIFF
--- a/test/osm_test.js
+++ b/test/osm_test.js
@@ -119,17 +119,22 @@ describe("L.OSM.DataLayer", function () {
     var layer = new L.OSM.DataLayer();
 
     it("returns true when the node is not in any ways", function () {
-      layer.interestingNode({}, []).should.be.true;
+      layer.interestingNode({}, [], []).should.be.true;
     });
 
     it("returns true when the node has an interesting tag", function () {
       var node = {tags: {interesting: true}};
-      layer.interestingNode(node, [{nodes: [node]}]).should.be.true;
+      layer.interestingNode(node, [{nodes: [node]}], []).should.be.true;
     });
 
     it("returns false when the node is used in a way and has uninteresting tags", function () {
       var node = {tags: {source: 'who cares?'}};
-      layer.interestingNode(node, [{nodes: [node]}]).should.be.false;
+      layer.interestingNode(node, [{nodes: [node]}], []).should.be.false;
+    });
+
+    it("returns true when the node is used in a way and is used in a relation", function () {
+      var node = {};
+      layer.interestingNode(node, [{nodes: [node]}], [{members: [node]}]).should.be.true;
     });
   });
 });


### PR DESCRIPTION
Now `interestingNode()` returns true for nodes which are direct members of a relation.

Please see my [pull request](https://github.com/openstreetmap/openstreetmap-website/issues/283) on openstreetmap-website which was the main reason for these additions.
