### PR TITLE
If http2 supported, disable tile domain sharding

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -1,8 +1,25 @@
 L.OSM = {};
 
+var h2 = false;
+// tile.openstreetmap.org supports http/2 where sharding makes no sense.
+// Use only one subdomain if we're using http/2
+if (
+    (window.performance && window.performance.getEntries      && performance.getEntries()[0].nextHopProtocol == 'h2') ||
+    (window.performance && performance.timing.nextHopProtocol && performance.timing.nextHopProtocol          == 'h2') ||
+    (window.chrome      && window.chrome.loadTimes            && window.chrome.loadTimes().connectionInfo    == 'h2')
+) {
+    h2 = true;
+}
+
+if (h2) {
+    var osmtileurl = 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
+} else {
+    var osmtileurl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+}
+
 L.OSM.TileLayer = L.TileLayer.extend({
   options: {
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    url: osmtileurl,
     attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
   },
 
@@ -44,9 +61,14 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
   }
 });
 
+if(h2) {
+    var osmgpsurl = 'https://gps-a.tile.openstreetmap.org/lines/{z}/{x}/{y}.png';
+} else {
+    var osmgpsurl = 'https://gps-{s}.tile.openstreetmap.org/lines/{z}/{x}/{y}.png';
+}
 L.OSM.GPS = L.OSM.TileLayer.extend({
   options: {
-    url: 'https://gps-{s}.tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
+    url: osmgpsurl,
     maxZoom: 21,
     maxNativeZoom: 20,
     subdomains: 'abc'

--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -1,25 +1,8 @@
 L.OSM = {};
 
-var h2 = false;
-// tile.openstreetmap.org supports http/2 where sharding makes no sense.
-// Use only one subdomain if we're using http/2
-if (
-    (window.performance && window.performance.getEntries      && performance.getEntries()[0].nextHopProtocol == 'h2') ||
-    (window.performance && performance.timing.nextHopProtocol && performance.timing.nextHopProtocol          == 'h2') ||
-    (window.chrome      && window.chrome.loadTimes            && window.chrome.loadTimes().connectionInfo    == 'h2')
-) {
-    h2 = true;
-}
-
-if (h2) {
-    var osmtileurl = 'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
-} else {
-    var osmtileurl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-}
-
 L.OSM.TileLayer = L.TileLayer.extend({
   options: {
-    url: osmtileurl,
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
     attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors'
   },
 
@@ -61,14 +44,9 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
   }
 });
 
-if(h2) {
-    var osmgpsurl = 'https://gps-a.tile.openstreetmap.org/lines/{z}/{x}/{y}.png';
-} else {
-    var osmgpsurl = 'https://gps-{s}.tile.openstreetmap.org/lines/{z}/{x}/{y}.png';
-}
 L.OSM.GPS = L.OSM.TileLayer.extend({
   options: {
-    url: osmgpsurl,
+    url: 'https://gps.tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
     maxZoom: 21,
     maxNativeZoom: 20,
     subdomains: 'abc'


### PR DESCRIPTION
Domain sharding [is an http/2 antipattern](https://love2dev.com/blog/domain-sharding-http-2/). Browsers and servers are supposed to detect sharding, but that doesn't always happen, for example if a.tile and b.tile resolve to different IP addresses - and even then, it still takes a bit of extra effort.

This detects whether the client is connecting over http/2, and instructs it not to use four subdomains to load tiles.

If the browser supports http/2, use a.tile.openstreetmap.org instead of {switch:a,b,c,d}.tile.openstreetmap.org and gps-a.tile.openstreetmap.org/lines/{z}/{x}/{y}.png instead of gps-{switch:a,b,c,d}.tile.openstreetmap.org/lines/{z}/{x}/{y}.png.