### PR TITLE
Remove node engine version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "engines": {
-    "node": "~0.8.4"
-  },
   "dependencies": {
     "leaflet": "0.6"
   },


### PR DESCRIPTION
This prevents using this library with `yarn` which does check that used version of node is compatible with the library.

I do not think this library has any strong requirement regarding node version.