### PR TITLE
Add asynchronous loading and removing functionality

### DIFF
--- a/test/osm_test.js
+++ b/test/osm_test.js
@@ -136,6 +136,71 @@ describe("L.OSM.DataLayer", function () {
     layers(osm)[0].options.should.have.property("color", "blue");
   });
 
+  describe("asynchronously", function() {
+    function sleep(time = 0) {
+      return new Promise(res => {
+        setTimeout(() => res(), time);
+      });
+    }
+
+    it("can be added to the map", function () {
+      (new L.OSM.DataLayer(null, {asynchronous: true})).addTo(this.map);
+    });
+  
+    it("creates a Polyline for a way", async function () {
+      var osm = new L.OSM.DataLayer(fixture("way"), {asynchronous: true});
+      await sleep(1);
+      layers(osm).length.should.eq(21);
+      layers(osm)[20].should.be.an.instanceof(L.Polyline);
+    });
+  
+    it("creates a Polygon for an area", async function () {
+      var osm = new L.OSM.DataLayer(fixture("area"), {asynchronous: true});
+      await sleep(1);
+      layers(osm).length.should.eq(15);
+      layers(osm)[14].should.be.an.instanceof(L.Polygon);
+    });
+  
+    it("creates a CircleMarker for an interesting node", async function () {
+      var osm = new L.OSM.DataLayer(fixture("node"), {asynchronous: true});
+      await sleep(1);
+      layers(osm).length.should.eq(1);
+      layers(osm)[0].should.be.an.instanceof(L.CircleMarker);
+    });
+  
+    it("creates a Rectangle for a changeset", async function () {
+      var osm = new L.OSM.DataLayer(fixture("changeset"), {asynchronous: true});
+      await sleep(1);
+      layers(osm).length.should.eq(1);
+      layers(osm)[0].should.be.an.instanceof(L.Rectangle);
+    });
+  
+    it("sets the feature property on a layer", async function () {
+      var osm = new L.OSM.DataLayer(fixture("node"), {asynchronous: true});
+      await sleep(1);
+      layers(osm)[0].feature.should.have.property("type", "node");
+      layers(osm)[0].feature.should.have.property("id", "356552551");
+    });
+  
+    it("sets a way's style", async function () {
+      var osm = new L.OSM.DataLayer(fixture("way"), {styles: {way: {color: "red"}}, asynchronous: true});
+      await sleep(1);
+      layers(osm)[20].options.should.have.property("color", "red");
+    });
+  
+    it("sets an area's style", async function () {
+      var osm = new L.OSM.DataLayer(fixture("area"), {styles: {area: {color: "green"}}, asynchronous: true});
+      await sleep(1);
+      layers(osm)[14].options.should.have.property("color", "green");
+    });
+  
+    it("sets a node's style", async function () {
+      var osm = new L.OSM.DataLayer(fixture("node"), {styles: {node: {color: "blue"}}, asynchronous: true});
+      await sleep(1);
+      layers(osm)[0].options.should.have.property("color", "blue");
+    });
+  });
+
   describe("#buildFeatures", function () {
     it("builds a node object", function () {
       var features = new L.OSM.DataLayer().buildFeatures(fixture("node"));


### PR DESCRIPTION
This PR addresses "Map Data checkbox: perhaps use toggle slider instead" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/4931

Several changes were made to the data loading functionality:

1. Rendering process will be asynchronous. Therefore, there will be no more browser or page freezes (see "Render Video").
2. Removing process will be also asynchronous and there won't be any freezes (see "Remove Video").

- While objects are being rendered, removing won't be triggered until the rendering process is done. After the process, application will check, and it will start removing rendered objects if necessary. The same applies vice versa.

Connected to the PR https://github.com/openstreetmap/openstreetmap-website/pull/5009
Fixes https://github.com/openstreetmap/openstreetmap-website/issues/4931

### Videos:

Render Video

https://github.com/user-attachments/assets/8e11fc5f-1d9c-4458-a5a8-96479627d5ff

Remove Video

https://github.com/user-attachments/assets/0743916d-353e-4717-8600-c74937b6f2fe

