### PR TITLE
Speed up data processing for the data layer

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -147,9 +147,25 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
       ways = L.OSM.getWays(xml, nodes),
       relations = L.OSM.getRelations(xml, nodes, ways);
 
+    var wayNodes = {}
+    for (var i = 0; i < ways.length; i++) {
+      var way = ways[i];
+      for (var j = 0; j < way.nodes.length; j++) {
+        wayNodes[way.nodes[j].id] = true
+      }
+    }
+
+    var relationNodes = {}
+    for (var i = 0; i < relations.length; i++){
+      var relation = relations[i];
+      for (var j = 0; j < relation.members.length; j++) {
+        relationNodes[relation.members[j].id] = true
+      }
+    }
+
     for (var node_id in nodes) {
       var node = nodes[node_id];
-      if (this.interestingNode(node, ways, relations)) {
+      if (this.interestingNode(node, wayNodes, relationNodes)) {
         features.push(node);
       }
     }
@@ -176,23 +192,9 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
     return false;
   },
 
-  interestingNode: function (node, ways, relations) {
-    var used = false;
-
-    for (var i = 0; i < ways.length; i++) {
-      if (ways[i].nodes.indexOf(node) >= 0) {
-        used = true;
-        break;
-      }
-    }
-
-    if (!used) {
-      return true;
-    }
-
-    for (var i = 0; i < relations.length; i++) {
-      if (relations[i].members.indexOf(node) >= 0)
-        return true;
+  interestingNode: function (node, wayNodes, relationNodes) {
+    if (!wayNodes[node.id] || relationNodes[node.id]) {
+      return true
     }
 
     for (var key in node.tags) {
@@ -309,7 +311,7 @@ L.Util.extend(L.OSM, {
         else // relation-way and relation-relation membership not implemented
           rel_object.members[j] = null;
       }
-
+      rel_object.members = rel_object.members.filter(i => i !== null && i !== undefined)
       result.push(rel_object);
     }
 

--- a/test/osm_test.js
+++ b/test/osm_test.js
@@ -146,54 +146,54 @@ describe("L.OSM.DataLayer", function () {
     it("can be added to the map", function () {
       (new L.OSM.DataLayer(null, {asynchronous: true})).addTo(this.map);
     });
-  
+
     it("creates a Polyline for a way", async function () {
       var osm = new L.OSM.DataLayer(fixture("way"), {asynchronous: true});
       await sleep(1);
       layers(osm).length.should.eq(21);
       layers(osm)[20].should.be.an.instanceof(L.Polyline);
     });
-  
+
     it("creates a Polygon for an area", async function () {
       var osm = new L.OSM.DataLayer(fixture("area"), {asynchronous: true});
       await sleep(1);
       layers(osm).length.should.eq(15);
       layers(osm)[14].should.be.an.instanceof(L.Polygon);
     });
-  
+
     it("creates a CircleMarker for an interesting node", async function () {
       var osm = new L.OSM.DataLayer(fixture("node"), {asynchronous: true});
       await sleep(1);
       layers(osm).length.should.eq(1);
       layers(osm)[0].should.be.an.instanceof(L.CircleMarker);
     });
-  
+
     it("creates a Rectangle for a changeset", async function () {
       var osm = new L.OSM.DataLayer(fixture("changeset"), {asynchronous: true});
       await sleep(1);
       layers(osm).length.should.eq(1);
       layers(osm)[0].should.be.an.instanceof(L.Rectangle);
     });
-  
+
     it("sets the feature property on a layer", async function () {
       var osm = new L.OSM.DataLayer(fixture("node"), {asynchronous: true});
       await sleep(1);
       layers(osm)[0].feature.should.have.property("type", "node");
       layers(osm)[0].feature.should.have.property("id", "356552551");
     });
-  
+
     it("sets a way's style", async function () {
       var osm = new L.OSM.DataLayer(fixture("way"), {styles: {way: {color: "red"}}, asynchronous: true});
       await sleep(1);
       layers(osm)[20].options.should.have.property("color", "red");
     });
-  
+
     it("sets an area's style", async function () {
       var osm = new L.OSM.DataLayer(fixture("area"), {styles: {area: {color: "green"}}, asynchronous: true});
       await sleep(1);
       layers(osm)[14].options.should.have.property("color", "green");
     });
-  
+
     it("sets a node's style", async function () {
       var osm = new L.OSM.DataLayer(fixture("node"), {styles: {node: {color: "blue"}}, asynchronous: true});
       await sleep(1);
@@ -219,22 +219,22 @@ describe("L.OSM.DataLayer", function () {
     var layer = new L.OSM.DataLayer();
 
     it("returns true when the node is not in any ways", function () {
-      layer.interestingNode({}, [], []).should.be.true;
+      layer.interestingNode({id: 1}, {}, {}).should.be.true;
     });
 
     it("returns true when the node has an interesting tag", function () {
-      var node = {tags: {interesting: true}};
-      layer.interestingNode(node, [{nodes: [node]}], []).should.be.true;
+      var node = {id: 1, tags: {interesting: true}};
+      layer.interestingNode(node, {1: true}, {1: true}).should.be.true;
     });
 
     it("returns false when the node is used in a way and has uninteresting tags", function () {
-      var node = {tags: {source: 'who cares?'}};
-      layer.interestingNode(node, [{nodes: [node]}], []).should.be.false;
+      var node = {id: 1, tags: {source: 'who cares?'}};
+      layer.interestingNode(node, {1: true}, {}).should.be.false;
     });
 
     it("returns true when the node is used in a way and is used in a relation", function () {
-      var node = {};
-      layer.interestingNode(node, [{nodes: [node]}], [{members: [node]}]).should.be.true;
+      var node = {id: 1};
+      layer.interestingNode(node, {1: true}, {1: true}).should.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR doesn't fix the issue https://github.com/openstreetmap/openstreetmap-website/issues/5466

It fixes a problem that will show up after it is fixed. But you can notice it now.

1. Load a large area of ​​the map and wait for the /map method to finish loading
2. You will have to wait a few seconds for the data to be processed before you see the warning.

On flame graph it now looks like this:

<img width="1425" alt="Снимок экрана 2025-01-05 в 18 53 35" src="https://github.com/user-attachments/assets/1d2d0136-7aa8-4841-8670-929b1fe8d99c" />

https://share.firefox.dev/4a3ZXM9

The error lies in the quadratic complexity of the data processing algorithm.

Suppose you have loaded 3000 nodes and they are all in ways. (it’s easy to imagine buildings in a city or roads) Now the algorithm for each loaded node makes a traversal through all nodes of all ways and members in the relations. We get 3000*3000 ~ 9,000,000 operations!

The situation is also aggravated by the fact that the array of relation members keeps members that are not nodes and you still traversal them for each loaded point!

Total:

1. Replace indexof() with a hashmaps of loaded nodes.
2. Remove null and undefined from the members of relations.

p.s. I'm not sure if you currently support new browsers, so I wrote code that does not use the new language features