### PR TITLE
Modernize L.OSM.XMLParser implementation

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -232,37 +232,33 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
 });
 
 L.OSM.XMLParser = {
-  getChangesets: function (xml) {
-    var result = [];
-
-    var nodes = xml.getElementsByTagName("changeset");
-    for (var i = 0; i < nodes.length; i++) {
-      var node = nodes[i], id = node.getAttribute("id");
-      result.push({
-        id: id,
-        type: "changeset",
-        latLngBounds: L.latLngBounds(
-          [node.getAttribute("min_lat"), node.getAttribute("min_lon")],
-          [node.getAttribute("max_lat"), node.getAttribute("max_lon")]),
-        tags: this.getTags(node)
-      });
-    }
-
-    return result;
+  getChangesets(xml) {
+    const changesets = [...xml.getElementsByTagName("changeset")];
+    return changesets.map(cs => ({
+      id: String(cs.getAttribute("id")),
+      type: "changeset",
+      latLngBounds: L.latLngBounds(
+        [cs.getAttribute("min_lat"), cs.getAttribute("min_lon")],
+        [cs.getAttribute("max_lat"), cs.getAttribute("max_lon")]
+      ),
+      tags: this.getTags(cs)
+    }));
   },
 
-  getNodes: function (xml) {
-    var result = {};
+  getNodes(xml) {
+    const result = {};
+    const nodes = [...xml.getElementsByTagName("node")];
 
-    var nodes = xml.getElementsByTagName("node");
-    for (var i = 0; i < nodes.length; i++) {
-      var node = nodes[i], id = node.getAttribute("id");
+    for (const node of nodes) {
+      const id = node.getAttribute("id");
       result[id] = {
-        id: id,
+        id: String(id),
         type: "node",
-        latLng: L.latLng(node.getAttribute("lat"),
-                         node.getAttribute("lon"),
-                         true),
+        latLng: L.latLng(
+          node.getAttribute("lat"),
+          node.getAttribute("lon"),
+          true
+        ),
         tags: this.getTags(node)
       };
     }
@@ -270,63 +266,40 @@ L.OSM.XMLParser = {
     return result;
   },
 
-  getWays: function (xml, nodes) {
-    var result = [];
-
-    var ways = xml.getElementsByTagName("way");
-    for (var i = 0; i < ways.length; i++) {
-      var way = ways[i], nds = way.getElementsByTagName("nd");
-
-      var way_object = {
-        id: way.getAttribute("id"),
+  getWays(xml, nodes) {
+    const ways = [...xml.getElementsByTagName("way")];
+    return ways.map(way => {
+      const nds = [...way.getElementsByTagName("nd")];
+      return {
+        id: String(way.getAttribute("id")),
         type: "way",
-        nodes: new Array(nds.length),
+        nodes: nds.map(nd => nodes[nd.getAttribute("ref")]),
         tags: this.getTags(way)
       };
-
-      for (var j = 0; j < nds.length; j++) {
-        way_object.nodes[j] = nodes[nds[j].getAttribute("ref")];
-      }
-
-      result.push(way_object);
-    }
-
-    return result;
+    });
   },
 
-  getRelations: function (xml, nodes, ways) {
-    var result = [];
-
-    var rels = xml.getElementsByTagName("relation");
-    for (var i = 0; i < rels.length; i++) {
-      var rel = rels[i], members = rel.getElementsByTagName("member");
-
-      var rel_object = {
-        id: rel.getAttribute("id"),
+  getRelations(xml, nodes, ways) {
+    const rels = [...xml.getElementsByTagName("relation")];
+    return rels.map(rel => {
+      const members = [...rel.getElementsByTagName("member")];
+      return {
+        id: String(rel.getAttribute("id")),
         type: "relation",
-        members: new Array(members.length),
+        members: members    // relation-way and relation-relation membership not implemented
+          .map(member => member.getAttribute("type") === "node" ? nodes[member.getAttribute("ref")] : null)
+          .filter(Boolean),    // filter out null and undefined
         tags: this.getTags(rel)
       };
-
-      for (var j = 0; j < members.length; j++) {
-        if (members[j].getAttribute("type") === "node")
-          rel_object.members[j] = nodes[members[j].getAttribute("ref")];
-        else // relation-way and relation-relation membership not implemented
-          rel_object.members[j] = null;
-      }
-      rel_object.members = rel_object.members.filter(i => i !== null && i !== undefined)
-      result.push(rel_object);
-    }
-
-    return result;
+    });
   },
 
-  getTags: function (xml) {
-    var result = {};
+  getTags(xml) {
+    const result = {};
+    const tags = [...xml.getElementsByTagName("tag")];
 
-    var tags = xml.getElementsByTagName("tag");
-    for (var j = 0; j < tags.length; j++) {
-      result[tags[j].getAttribute("k")] = tags[j].getAttribute("v");
+    for (const tag of tags) {
+      result[tag.getAttribute("k")] = tag.getAttribute("v");
     }
 
     return result;


### PR DESCRIPTION
Follow up for:
> Even better would be to refactor the XML parser along the same lines as the JSON parser after fixing the XML tests and before adding the JSON parser but that's obviously not essential so I wouldn't insist on that.

Here's an attempt to make the XML parser resemble the JSON implementation. All the `getElementsByTagName` and `getAttribute` tend to make the code more difficult to read, compared to the JSON version. YMMV.