### PR TITLE
Add functionality to cancel data loading

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -104,6 +104,13 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
     }
   },
 
+  loadingLayers: [],
+
+  cancelLoading: function () {
+    this.loadingLayers.forEach(layer => clearTimeout(layer));
+    this.loadingLayers = [];
+  },
+
   addData: function (features) {
     if (!(features instanceof Array)) {
       features = this.buildFeatures(features);
@@ -220,9 +227,11 @@ L.OSM.DataLayer = L.FeatureGroup.extend({
   eachLayer: function (method, context, asynchronous = false) {
     for (let i in this._layers) {
       if (asynchronous) {
-        setTimeout(() => {
-          method.call(context, this._layers[i]);
-        });
+        this.loadingLayers.push(
+          setTimeout(() => {
+            method.call(context, this._layers[i]);
+          })
+        );
       } else {
         method.call(context, this._layers[i]);
       }


### PR DESCRIPTION
This PR addresses "Map Data checkbox: perhaps use toggle slider instead" issue mentioned in the https://github.com/openstreetmap/openstreetmap-website/issues/4931 and https://github.com/openstreetmap/openstreetmap-website/pull/5009#issuecomment-2369641597. It is continuation of https://github.com/openstreetmap/leaflet-osm/pull/38.

Currently `asynchronously loading data` has no functionality to be canceled. Therefore, if user starts loading big amount of data and in the middle of the process decides to cancel it (even if `removing each layer` was called), it will load all elements asynchronously (and only after that will begin to remove all the elements).

This PR adds functionality to cancel asynchronous loading/removing in the middle of the process.

Was manually tested in the https://github.com/openstreetmap/openstreetmap-website/pull/5009

Connected to the PR https://github.com/openstreetmap/openstreetmap-website/pull/5009