### PR TITLE
Use webp format for tracestrack topo

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -71,7 +71,7 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
 
 L.OSM.TracestrackTopo = L.OSM.TileLayer.extend({
   options: {
-    url: 'https://tile.tracestrack.com/topo__/{z}/{x}/{y}.png?key={apikey}',
+    url: 'https://tile.tracestrack.com/topo__/{z}/{x}/{y}.webp?key={apikey}',
     maxZoom: 19,
     attribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. Tiles courtesy of <a href="https://www.tracestrack.com/" target="_blank">Tracestrack Maps</a>'
   }

--- a/test/osm_test.js
+++ b/test/osm_test.js
@@ -62,7 +62,7 @@ describe("L.OSM.OPNVKarte", function () {
 
 describe("L.OSM.TracestrackTopo", function () {
   it("has the appropriate URL", function () {
-    new L.OSM.TracestrackTopo()._url.should.eq('https://tile.tracestrack.com/topo__/{z}/{x}/{y}.png?key={apikey}');
+    new L.OSM.TracestrackTopo()._url.should.eq('https://tile.tracestrack.com/topo__/{z}/{x}/{y}.webp?key={apikey}');
   });
 
   it("has the appropriate attribution", function () {


### PR DESCRIPTION
Tracestrack Maps recently started providing webp tiles. webp is widely supported and has better compression. It loads faster without noticeable quality degradation. This is the preferred way to serve tiles.

https://github.com/openstreetmap/openstreetmap-website/pull/5996